### PR TITLE
feat(0.2.5): se agrego panel de salud de sincronización automática

### DIFF
--- a/includes/admin-hooks.php
+++ b/includes/admin-hooks.php
@@ -33,6 +33,25 @@ function nb_enqueue_admin_styles($hook) {
 }
 add_action('admin_enqueue_scripts', 'nb_enqueue_admin_styles');
 
+/**
+ * Watchdog: si el evento de cron se perdió (por ejemplo, tras una
+ * actualización sin reactivar el plugin), lo reprograma. Corre solo
+ * en las páginas del propio plugin para no pagar el costo en cada
+ * carga de /wp-admin/ del sitio.
+ */
+function nb_cron_watchdog($screen)
+{
+    if ($screen->id !== 'settings_page_nb' && $screen->id !== 'tools_page_nb-logs') {
+        return;
+    }
+
+    if (!wp_next_scheduled('nb_cron_sync_event')) {
+        nb_update_cron_schedule();
+        nb_log('Watchdog: evento nb_cron_sync_event no estaba programado, se reprogramó automáticamente', 'warning');
+    }
+}
+add_action('current_screen', 'nb_cron_watchdog');
+
 function nb_register_settings()
 {
     register_setting('nb_options', 'nb_user');
@@ -160,6 +179,8 @@ function nb_uninstall()
     delete_option('nb_description');
     delete_option('nb_sync_interval');
     delete_option('nb_last_update');
+    delete_option('nb_last_auto_sync');
+    delete_option('nb_last_manual_sync');
     
     // 3. Limpiar transients relacionados (si existen)
     delete_transient('nb_api_token');

--- a/includes/cron-health.php
+++ b/includes/cron-health.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Diagnóstico de salud del cron de sincronización automática.
+ * Explica al cliente, sin acceso a servidor, por qué la sincronización
+ * automática puede no estar corriendo (WP-Cron depende de visitas HTTP).
+ */
+
+function nb_get_cron_health()
+{
+    $interval_seconds = intval(get_option('nb_sync_interval', 3600));
+    $next_scheduled = wp_next_scheduled('nb_cron_sync_event');
+    $last_auto_sync = get_option('nb_last_auto_sync');
+    $last_manual_sync = get_option('nb_last_manual_sync');
+    $nb_user = get_option('nb_user');
+    $nb_password = get_option('nb_password');
+
+    $active_plugins = get_option('active_plugins', array());
+    $plugin_active = false;
+    foreach ($active_plugins as $plugin) {
+        if (strpos($plugin, 'woocommerce-newbytes') !== false && strpos($plugin, '.php') !== false) {
+            $plugin_active = true;
+            break;
+        }
+    }
+
+    $grace_period = max(900, $interval_seconds * 2);
+    $overdue_by_seconds = null;
+    $is_overdue = false;
+    if ($next_scheduled && time() > $next_scheduled + $grace_period) {
+        $is_overdue = true;
+        $overdue_by_seconds = time() - $next_scheduled;
+    }
+
+    $health = array(
+        'severity'              => 'ok',
+        'message'                => 'La sincronización automática está funcionando correctamente.',
+        'next_scheduled'         => $next_scheduled,
+        'next_scheduled_human'   => $next_scheduled ? date_i18n('d/m/Y H:i', $next_scheduled) : null,
+        'is_overdue'             => $is_overdue,
+        'overdue_by_seconds'     => $overdue_by_seconds,
+        'disable_wp_cron'        => defined('DISABLE_WP_CRON') && DISABLE_WP_CRON,
+        'alternate_wp_cron'      => defined('ALTERNATE_WP_CRON') && ALTERNATE_WP_CRON,
+        'interval_seconds'       => $interval_seconds,
+        'last_auto_sync'         => $last_auto_sync ?: null,
+        'last_manual_sync'       => $last_manual_sync ?: null,
+        'plugin_active'          => $plugin_active,
+        'credentials_configured' => !empty($nb_user) && !empty($nb_password),
+    );
+
+    if (!$health['credentials_configured']) {
+        $health['severity'] = 'error';
+        $health['message'] = 'No hay credenciales configuradas. La sincronización automática no puede ejecutarse hasta completar el usuario y la contraseña en la pestaña Credenciales.';
+    } elseif ($next_scheduled === false) {
+        $health['severity'] = 'error';
+        $health['message'] = 'No hay ninguna sincronización automática programada. Volvé a cargar esta página; si el aviso persiste, contactá a soporte.';
+    } elseif ($health['disable_wp_cron']) {
+        $health['severity'] = 'warning';
+        $health['message'] = 'El cron automático de WordPress está desactivado en este sitio (DISABLE_WP_CRON). Para que la sincronización corra sola, el hosting debe configurar una tarea cron de servidor que visite wp-cron.php de forma periódica.';
+    } elseif ($is_overdue) {
+        $ciclos_perdidos = $interval_seconds > 0 ? floor($overdue_by_seconds / $interval_seconds) : 0;
+        $health['severity'] = ($overdue_by_seconds > $interval_seconds * 3) ? 'error' : 'warning';
+        $health['message'] = sprintf(
+            'La sincronización automática debería haberse ejecutado hace %s y no corrió (se perdieron aproximadamente %d ciclo(s)). Esto suele pasar cuando el sitio recibe poco tráfico o el hosting no dispara wp-cron.php. Pedile a tu hosting que configure un cron de servidor real.',
+            human_time_diff($next_scheduled, time()),
+            $ciclos_perdidos
+        );
+    }
+
+    return $health;
+}
+
+function nb_build_diagnostic_text($health)
+{
+    $severity_labels = array(
+        'ok'      => 'OK',
+        'warning' => 'ADVERTENCIA',
+        'error'   => 'ERROR',
+    );
+
+    $lines = array();
+    $lines[] = '=== Diagnóstico NewBytes Conector ===';
+    $lines[] = 'Estado: ' . $severity_labels[$health['severity']];
+    $lines[] = 'Mensaje: ' . $health['message'];
+    $lines[] = 'Próxima sync programada: ' . ($health['next_scheduled_human'] ?: 'no programada');
+    $lines[] = 'Última sync automática: ' . ($health['last_auto_sync'] ? human_time_diff(strtotime($health['last_auto_sync'])) . ' atrás' : 'Nunca');
+    $lines[] = 'Última sync manual: ' . ($health['last_manual_sync'] ? human_time_diff(strtotime($health['last_manual_sync'])) . ' atrás' : 'Nunca');
+    $lines[] = 'Intervalo configurado: cada ' . round($health['interval_seconds'] / 3600, 1) . ' hora(s)';
+    $lines[] = 'DISABLE_WP_CRON activo: ' . ($health['disable_wp_cron'] ? 'sí' : 'no');
+    $lines[] = 'Fecha del reporte: ' . date_i18n('d/m/Y H:i');
+
+    return implode("\n", $lines);
+}
+
+function nb_ajax_refresh_cron_health()
+{
+    if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'nb_sync_nonce')) {
+        wp_send_json_error(array('message' => 'Nonce inválido'));
+    }
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error(array('message' => 'Sin permisos'));
+    }
+
+    try {
+        $health = nb_get_cron_health();
+        $health['diagnostic_text'] = nb_build_diagnostic_text($health);
+        wp_send_json_success($health);
+    } catch (Exception $e) {
+        wp_send_json_error(array('message' => 'Error: ' . $e->getMessage()));
+    }
+}
+add_action('wp_ajax_nb_refresh_cron_health', 'nb_ajax_refresh_cron_health');

--- a/includes/cron-hooks.php
+++ b/includes/cron-hooks.php
@@ -359,7 +359,14 @@ function nb_callback($syncDescription = false)
         $execution_time = ($end_time - $start_time);
 
         // Actualizar la fecha de última actualización
-        update_option('nb_last_update', current_time('mysql'));
+        $current_mysql_time = current_time('mysql');
+        update_option('nb_last_update', $current_mysql_time);
+
+        if ($sync_type === 'auto') {
+            update_option('nb_last_auto_sync', $current_mysql_time);
+        } else {
+            update_option('nb_last_manual_sync', $current_mysql_time);
+        }
 
         // Preparar estadísticas finales
         $final_stats = array(

--- a/includes/settings-v3.php
+++ b/includes/settings-v3.php
@@ -236,6 +236,37 @@ function nb_options_page()
     echo '<p class="nb-form-hint">Se añadirá al final de la descripción de cada producto</p>';
     echo '</div>';
     
+    // Estado de salud de la sincronización automática
+    $cron_health = nb_get_cron_health();
+    $diagnostic_text = nb_build_diagnostic_text($cron_health);
+    $severity_class = array(
+        'ok'      => 'nb-alert-success',
+        'warning' => 'nb-alert-warning',
+        'error'   => 'nb-alert-error',
+    )[$cron_health['severity']];
+
+    echo '<div class="nb-alert ' . $severity_class . ' nb-mb-4" id="nb-cron-health-banner">';
+    echo '<svg class="nb-alert-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>';
+    echo '<div class="nb-alert-content">';
+    echo '<p class="nb-alert-title">Estado de sincronización automática</p>';
+    echo '<p class="nb-alert-text">' . esc_html($cron_health['message']) . '</p>';
+
+    echo '<div class="nb-data-row" style="margin-top:8px;">';
+    echo '<span class="nb-data-label">Última sync automática</span>';
+    echo '<span class="nb-data-value">' . esc_html($cron_health['last_auto_sync'] ? human_time_diff(strtotime($cron_health['last_auto_sync'])) . ' atrás' : 'Nunca') . '</span>';
+    echo '</div>';
+    echo '<div class="nb-data-row">';
+    echo '<span class="nb-data-label">Última sync manual</span>';
+    echo '<span class="nb-data-value">' . esc_html($cron_health['last_manual_sync'] ? human_time_diff(strtotime($cron_health['last_manual_sync'])) . ' atrás' : 'Nunca') . '</span>';
+    echo '</div>';
+
+    if ($cron_health['severity'] !== 'ok') {
+        echo '<button type="button" id="nb-sync-now-from-banner-btn" class="nb-btn nb-btn-sm nb-btn-primary nb-mt-2" style="margin-right:8px;">Sincronizar ahora</button>';
+    }
+    echo '<button type="button" id="nb-copy-diagnostics-btn" class="nb-btn nb-btn-sm nb-btn-secondary nb-mt-2" data-diagnostic="' . esc_attr($diagnostic_text) . '">Copiar diagnóstico</button>';
+    echo '</div>'; // nb-alert-content
+    echo '</div>'; // nb-alert
+
     // Info última sync
     $last_update_formatted = $last_update ? date('d/m/Y H:i', strtotime($last_update . '-3 hours')) : 'Nunca';
     echo '<div class="nb-data-row" style="margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--nb-border-primary);">';
@@ -585,6 +616,25 @@ function nb_render_scripts_v3()
         });
 
         // ============================================
+        // Copiar diagnóstico de salud del cron
+        // ============================================
+        $('#nb-copy-diagnostics-btn').on('click', function() {
+            var text = $(this).data('diagnostic');
+            if (navigator.clipboard) {
+                navigator.clipboard.writeText(text).then(function() {
+                    showToast('success', 'Copiado', 'Diagnóstico copiado al portapapeles');
+                }, function() {
+                    showToast('error', 'Error', 'No se pudo copiar. Copiá manualmente el texto.');
+                });
+            } else {
+                var $tmp = $('<textarea>').val(text).appendTo('body').select();
+                document.execCommand('copy');
+                $tmp.remove();
+                showToast('success', 'Copiado', 'Diagnóstico copiado al portapapeles');
+            }
+        });
+
+        // ============================================
         // SKU Preview
         // ============================================
         $('#nb_prefix').on('input', function() {
@@ -898,11 +948,12 @@ function nb_render_scripts_v3()
         var totalCreated = 0;
         var totalUpdated = 0;
 
-        $('#btn-prepare-sync').on('click', function() {
-            var $btn = $(this);
+        function startSync($btn) {
             $('#btn-prepare-sync-text').addClass('nb-hidden');
             $('#btn-prepare-sync-spinner').removeClass('nb-hidden');
-            $btn.prop('disabled', true);
+            if ($btn) {
+                $btn.prop('disabled', true);
+            }
 
             $.ajax({
                 url: '<?php echo $ajax_url; ?>',
@@ -914,7 +965,9 @@ function nb_render_scripts_v3()
                 success: function(response) {
                     $('#btn-prepare-sync-text').removeClass('nb-hidden');
                     $('#btn-prepare-sync-spinner').addClass('nb-hidden');
-                    $btn.prop('disabled', false);
+                    if ($btn) {
+                        $btn.prop('disabled', false);
+                    }
 
                     if (response.success) {
                         syncData = response.data;
@@ -929,10 +982,20 @@ function nb_render_scripts_v3()
                 error: function() {
                     $('#btn-prepare-sync-text').removeClass('nb-hidden');
                     $('#btn-prepare-sync-spinner').addClass('nb-hidden');
-                    $btn.prop('disabled', false);
+                    if ($btn) {
+                        $btn.prop('disabled', false);
+                    }
                     showToast('error', 'Error', 'Error de conexión');
                 }
             });
+        }
+
+        $('#btn-prepare-sync').on('click', function() {
+            startSync($(this));
+        });
+
+        $('#nb-sync-now-from-banner-btn').on('click', function() {
+            startSync($(this));
         });
 
         $('#nb-btn-cancel-sync').on('click', function() {

--- a/woocommerce-newbytes.php
+++ b/woocommerce-newbytes.php
@@ -4,17 +4,18 @@ Plugin Name: Conector NewBytes
 Description: Sincroniza los productos del catálogo de NewBytes con WooCommerce.
 Author: NewBytes
 Author URI: https://nb.com.ar
-Version: 0.2.4
+Version: 0.2.5
 */
 
 define('API_URL_NB', 'https://api.nb.com.ar/v1');
-define('VERSION_NB', '0.2.4');
+define('VERSION_NB', '0.2.5');
 
 // Incluye los archivos necesarios
 require_once plugin_dir_path(__FILE__) . 'includes/admin-hooks.php';
 require_once plugin_dir_path(__FILE__) . 'includes/utils.php';
 require_once plugin_dir_path(__FILE__) . 'includes/product-manager.php';
 require_once plugin_dir_path(__FILE__) . 'includes/cron-hooks.php';
+require_once plugin_dir_path(__FILE__) . 'includes/cron-health.php';
 require_once plugin_dir_path(__FILE__) . 'includes/rest-api.php';
 require_once plugin_dir_path(__FILE__) . 'includes/product-sync.php';
 require_once plugin_dir_path(__FILE__) . 'includes/product-delete.php';


### PR DESCRIPTION
```
Trackea por separado la última sincronización automática y manual
(nb_last_auto_sync / nb_last_manual_sync) y agrega nb_get_cron_health()
para detectar cuándo el cron de WordPress no se está disparando
(evento vencido, perdido, o DISABLE_WP_CRON activo), mostrando un
banner con el diagnóstico en español y un botón para copiarlo y
enviarlo a soporte/hosting.
```

```
Se agrega también un watchdog (enganchado a current_screen) que
reprograma el evento nb_cron_sync_event si se pierde, y un botón
"Sincronizar ahora" en el banner cuando la sync automática está
en advertencia o error, reutilizando el flujo de sincronización
manual ya existente en la pestaña Herramientas.
```